### PR TITLE
Fixes the check of instanceID

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -377,7 +377,18 @@ function handlePageResponse(data: PaginateResponse, localws: WebSocketAdapter, s
     const body = DataBody.decode(payload)
     body.txResults.forEach((transaction) => {
       transaction.clientTransaction.instructions.forEach((instruction) => {
-        if (instruction.instanceID.toString("hex") === contractID) {
+        if (instruction.spawn !== null) {
+          console.log("deriveID: ", instruction.deriveId("").toString("hex"))
+          if (instruction.deriveId("").toString("hex") === contractID) {
+            console.log("*****************Contract match found as spawn*****************")
+            if(!blocks.includes(data.blocks[i])){
+              instanceSearch = instruction
+              blocks.push(data.blocks[i])
+            }
+            printdataConsole(block, data.pagenumber)
+            printdataBox(block, data.pagenumber)
+          }
+        } else if (instruction.instanceID.toString("hex") === contractID) {
           console.log("*****************Contract match found*****************")
           if(!blocks.includes(data.blocks[i])){
             instanceSearch = instruction


### PR DESCRIPTION
The instanceID on the spawn instruction is, in fact, not the instanceID the new instance will have. To have the future instanceID of an instance that is not created yet (as it is the case here, since we are seeing only the *instruction* that asks to create the instance) one can use "deriveid". 

Note that for most of the instances on the production blockchain this method doesn't work, as the mechanism to spawn the instances uses a non "standard" method. So in your case you'll only see the "invoke" instructions., but this is normal. 